### PR TITLE
Disable color highlighting on large json files, and remove csvkit link

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
     if (json) {
       var pretty = JSON.stringify(json, undefined, 2);
       $(".json code").html(pretty);
-      if (pretty.length < (100 * 1024))
+      if (pretty.length < (50 * 1024))
         hljs.highlightBlock($(".json code").get(0));
     } else
       $(".json code").html("");

--- a/index.html
+++ b/index.html
@@ -66,7 +66,8 @@
     if (json) {
       var pretty = JSON.stringify(json, undefined, 2);
       $(".json code").html(pretty);
-      hljs.highlightBlock($(".json code").get(0));
+      if (pretty.length < (100 * 1024))
+        hljs.highlightBlock($(".json code").get(0));
     } else
       $(".json code").html("");
 
@@ -362,7 +363,7 @@
   </div>
 
   <div class="warning">
-    Extremely large files may cause trouble &mdash; the conversion is done inside your browser. In that case, try out the powerful <a href="http://csvkit.readthedocs.org/en/latest/scripts/in2csv.html">csvkit</a>.
+    Extremely large files may cause trouble &mdash; the conversion is done inside your browser.
   </div>
 </section>
 


### PR DESCRIPTION
The syntax highlighting code isn't worth it for large JSON files. Disabling it above a certain threshold makes the site work for larger files, even if it won't ever be able to handle super super large files.

This disables syntax highlighting for JSON blobs above 50KB. It also removes the top link to [`csvkit`](http://csvkit.readthedocs.org/en/0.9.0/), since the recursive flattening support in `csvkit` [seems to have regressed](https://github.com/onyxfish/csvkit/issues/366#issuecomment-68005428) (or something).

What it looks like for a larger file now:

![large file](https://cloud.githubusercontent.com/assets/4592/5544071/264bf672-8acd-11e4-8715-25f6df73c5dc.png)

Examples:
- 24KB JSON blob: http://konklone.io/json/?id=026996ae8641df750c71
- 400KB JSON blob: http://konklone.io/json/?id=300bf93cfa21d7d7bfce

Fixes #44.
