### PR TITLE
Default anonymous gists to be private

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
     // save a permalink to an anonymous gist
     var gist = {
       description: "test",
-      public: true,
+      public: false,
       files: {
         "source.json": {
             "content": input


### PR DESCRIPTION
It's not a great idea to default people's pastes to being public (when they create permalinks). Better to put people in charge of distributing the data themselves, through the permalink we create or by looking up the gist back end. I'm surprised I didn't notice this or think about it when I first deployed it.
