### PR TITLE
Prevent infinite loop on simple objects

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -46,8 +46,10 @@ function arrayFrom(json) {
     while (next !== undefined) {
         if ($.type(next) == "array")
             return next;
-        for (var key in next)
-           queue.push(next[key]);
+        if ($.type(next) == "object") {
+          for (var key in next)
+             queue.push(next[key]);
+        }
         next = queue.shift();
     }
     // none found, consider the whole object a row

--- a/index.html
+++ b/index.html
@@ -57,8 +57,6 @@
       return;
     }
 
-    console.log("ordered to parse JSON...");
-
     var json = jsonFrom(input);
 
     // if succeeded, prettify and highlight it
@@ -70,6 +68,7 @@
         hljs.highlightBlock($(".json code").get(0));
     } else
       $(".json code").html("");
+
 
     // convert to CSV, make available
     doCSV(json);


### PR DESCRIPTION
`{"anonymous": "gist"}` was crashing this consistently, by walking over scalars. This limits recursive walking to over objects.
