### PR TITLE
Be more flexible on JSON, add proper error reporting

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -45,6 +45,11 @@ h1 {
 .csv .rendered {display: none;}
 
 .json .warning {margin-top: 5px; color: #888;}
+.json .error {
+  display: none;
+  margin-top: 5px;
+  color: #a00; font-weight: normal;
+}
 .json .permalink {display: none;}
 
 .csv {color: black;margin-top: 30px;}

--- a/assets/site.css
+++ b/assets/site.css
@@ -44,6 +44,7 @@ h1 {
 .csv textarea {}
 .csv .rendered {display: none;}
 
+.json .error a.report {font-weight: bold;}
 .json .warning {margin-top: 5px; color: #888;}
 .json .error {
   display: none;

--- a/assets/site.js
+++ b/assets/site.js
@@ -56,9 +56,39 @@ function arrayFrom(json) {
     return [json];
 }
 
+// adapted from Mattias Petter Johanssen:
+// https://www.quora.com/How-can-I-parse-unquoted-JSON-with-JavaScript/answer/Mattias-Petter-Johansson
+function quoteKeys(input) {
+  return input.replace(/(['"])?([a-zA-Z0-9_]+)(['"])?:/g, '"$2": ');
+}
+
+function removeTrailingComma(input) {
+  if (input.slice(-1) == ",")
+    return input.slice(0,-1);
+  else
+    return input;
+}
+
 // todo: add graceful error handling
 function jsonFrom(input) {
   var string = $.trim(input);
   if (!string) return;
-  return JSON.parse(string);
+
+  var result = null;
+  try {
+    result = JSON.parse(string);
+  } catch (err) {
+    console.log(err);
+    console.log("Parse failed, retrying after forcibly quoting keys and removing trailing commas...")
+
+    try {
+      result = JSON.parse(quoteKeys(removeTrailingComma(string)))
+      console.log("Yep: quoting keys and removing trailing commas worked.")
+    } catch (err) {
+      console.log(err);
+      console.log("Nope: that didn't work either. No good.")
+    }
+  }
+
+  return result;
 }

--- a/assets/site.js
+++ b/assets/site.js
@@ -44,9 +44,18 @@ function parse_object(obj, path) {
 function arrayFrom(json) {
     var queue = [], next = json;
     while (next !== undefined) {
-        if ($.type(next) == "array")
-            return next;
-        if ($.type(next) == "object") {
+        if ($.type(next) == "array") {
+
+            // but don't if it's just empty, or an array of scalars
+            if (next.length > 0) {
+
+              var type = $.type(next[0]);
+              var scalar = (type == "number" || type == "string" || type == "boolean" || type == "null");
+
+              if (!scalar)
+                return next;
+            }
+        } if ($.type(next) == "object") {
           for (var key in next)
              queue.push(next[key]);
         }

--- a/index.html
+++ b/index.html
@@ -70,18 +70,18 @@
       $(".json code").html(pretty);
       if (pretty.length < (50 * 1024))
         hljs.highlightBlock($(".json code").get(0));
+
+      // convert to CSV, make available
+      doCSV(json);
     } else {
       // Show error.
       $("div.warning").hide();
       $("div.error").show();
       $(".json code").html("");
-
-      return;
     }
 
-
-    // convert to CSV, make available
-    doCSV(json);
+    // Either way, update the error-reporting link to include the latest.
+    setErrorReporting(null, input);
 
     return true;
   }
@@ -210,6 +210,9 @@
       // mark what we last saved
       lastSaved = input;
 
+      // update error-reporting link, including permalink
+      setErrorReporting(data.id, input);
+
       console.log("Remaining this hour: " + xhr.getResponseHeader("X-RateLimit-Remaining"));
 
     }).fail(function(xhr, status, errorThrown) {
@@ -227,6 +230,44 @@
     });
 
     return false;
+  }
+
+  // Updates the error-reporting link to include current details.
+  //
+  // If the passed-in `id` is not null, a permalink is included.
+  // If the passed-in `id` is null, then no permalink is included.
+  // (Needed explicitly because the current URL doesn't always refer
+  // to a permalink related to the current value of the textarea.)
+  //
+  // The current body of the textarea will be encoded into the URI,
+  // to pre-populate the GitHub issue template, but only if the body
+  // is < 7KB (7,168). GitHub's nginx server rejects query strings
+  // longer than ~8KB.
+  //
+  // If no `id` is given, and content is too long, the URL will
+  // encode only a title, and no body.
+  function setErrorReporting(id, content) {
+    var base = "https://github.com/konklone/json/issues/new";
+
+    var title = "Error parsing some specific JSON";
+
+    var body = "I'm having an issue converting this JSON:\n\n";
+    if (id) body += (
+      window.location.protocol + "//" +
+      window.location.host + window.location.pathname +
+      "?id=" + id + "\n\n"
+    );
+
+    if (content.length <= (7 * 1024))
+      body += ("```json\n" + content + "\n```");
+
+    var finalUrl = base + "?title=" + encodeURIComponent(title) +
+      "&body=" + encodeURIComponent(body);
+
+    $(".error a.report").attr("href", finalUrl);
+
+    // console.log("Updated error reporting link to:" + finalUrl);
+    return true;
   }
 
   // given a valid gist ID, set the permalink to use it
@@ -362,7 +403,7 @@
     </span>
 
     <span>
-      Please <a href="https://github.com/konklone/json/issues">report bugs and send feedback</a> on GitHub.
+      Please <a target="_blank" href="https://github.com/konklone/json/issues">report bugs and send feedback</a> on GitHub.
     </span>
 
     <span>
@@ -381,14 +422,13 @@
   </div>
 
   <div class="error">
-    There was an error parsing this JSON. If you're sure this JSON is valid,
-    <a class="save" href="#">
-      create a permalink to this error
-    </a> and
-    <a target="_blank"
+    There was an error parsing this JSON. If you're sure this JSON is valid, please
+    <a class="report" target="_blank"
       href="https://github.com/konklone/json/issues/new">
-      file an issue
-    </a> including that permalink.
+      file an issue</a>.
+    You can
+    <a class="save" href="#">create a permalink to the error</a>
+    any time.
   </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -62,12 +62,22 @@
     // if succeeded, prettify and highlight it
     // highlight shows when textarea loses focus
     if (json) {
+      // Reset any error message from previous failed parses.
+      $("div.error").hide();
+      $("div.warning").show();
+
       var pretty = JSON.stringify(json, undefined, 2);
       $(".json code").html(pretty);
       if (pretty.length < (50 * 1024))
         hljs.highlightBlock($(".json code").get(0));
-    } else
+    } else {
+      // Show error.
+      $("div.warning").hide();
+      $("div.error").show();
       $(".json code").html("");
+
+      return;
+    }
 
 
     // convert to CSV, make available
@@ -265,7 +275,8 @@
       return !!$(".csv textarea").val();
     });
 
-    $(".save a").click(saveJSON);
+    // Both elements are present on page-load, so use normal click handler.
+    $(".save a, .error a.save").click(saveJSON);
 
     // transform the JSON whenever it's pasted/edited
     $(".json textarea")
@@ -367,6 +378,17 @@
 
   <div class="warning">
     Extremely large files may cause trouble &mdash; the conversion is done inside your browser.
+  </div>
+
+  <div class="error">
+    There was an error parsing this JSON. If you're sure this JSON is valid,
+    <a class="save" href="#">
+      create a permalink to this error
+    </a> and
+    <a target="_blank"
+      href="https://github.com/konklone/json/issues/new">
+      file an issue
+    </a> including that permalink.
   </div>
 </section>
 


### PR DESCRIPTION
Mostly in response to #65, this does a few things:
- Allows for unquoted keys, e.g. `{a: 1, b: 2}`. This is not valid JSON, but it is nonetheless common, including when copy/pasting from some source of valid JSON. This is implemented using a regex, not using `eval()`. The regex is only run if the first call to `JSON.parse()` fails, so we're not needlessly running this regex over every pasted-in content (only initial failures).
- Allows for trailing commas, e.g. `{"a": 1, "b": 2},`. This is also not valid JSON, but it is also nonetheless common, especially when copy/pasting an object from within a valid JSON array. This is implemented using `Array#slice`, which I believe is implemented pretty efficiently in most browsers using an in-place memory buffer. Nonetheless, it's also only performed if the first parse attempt fails.
- Stops the "array-guessing" function (that determines which array whose items will constitute each row of the resulting CSV) from choosing empty arrays, or arrays of scalars (strings, numbers, booleans, and `null`s). The array-guessing code is meant to allow an object whose core items are an array that's a value inside a wrapper object, which is a pretty common pattern. But we don't want that array-guessing to stop if it finds an array of scalar strings (e.g. `"tags": ["a", "b", "c"]`). It's also not useful for it to stop at an empty array. This is applied during the recursive array-hunting function, and the scalar test just evaluates the first entry in the array (if it's non-empty). It's not perfect, but should handle most useful cases.

This also adds proper error handling:

![image](https://cloud.githubusercontent.com/assets/4592/13205650/59d0a6bc-d8b2-11e5-9350-3f18d52acae2.png)
- If the pasted in content fails to parse (even after applying the relaxed checks above), the little warning about too-big content changes to a set of red warning text saying there was an issue.
- The error reporting link includes `title=` and `body=` query string values containing a generic title and a body specific to the text that was failed to parse. This is a (undocumented?) feature in GitHub that allows you to do on-the-fly issue templating.
- The error block has its own permalink creation link as well, to encourage users to do this for errors too. Clicking _either_ permalink creation link will cause the error reporting link's query string to update to also include the last generated permalink, which should increase the chances of a permalink ending up in a filed report. (If the user makes any changes to the text after clicking the permalink button, the error reporting link will auto-update with that text _without_ the permalink, which is what we want. So there should never be a case of a stale permalink entering the issue template with text it's not matched to.)
- The issue template body will only include the JSON if it's 7K or less. GitHub's nginx server blocks a query string and returns a `413 Entity Too Large` error if it's around ~8K or more. Worst case is the issue template is mostly blank, and the user will have to copy/paste it themselves (which the hanging intro in the issue should encourage them to do).

The error reporting link opens in a new tab. I also made the feedback link at the top open in a new tab, though it does not include the current textarea content (since it should be friendly to filing generic issues).

cc @scottmunro
