### PR TITLE
Add a few analytics events

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -7,8 +7,8 @@ Events = {
     ga('send', 'event', 'permalink', 'error', "" + value);
   },
 
-  download: function() {
-    ga('send', 'event', 'download', 'clicked');
+  download: function(size) {
+    ga('send', 'event', 'download', 'clicked', 'size', size);
   }
 
 }

--- a/assets/site.js
+++ b/assets/site.js
@@ -1,6 +1,6 @@
 Events = {
-  permalink: function(id) {
-    ga('send', 'event', 'permalink', 'created', id)
+  permalink: function() {
+    ga('send', 'event', 'permalink', 'created')
   },
 
   permalink_error: function(value) {

--- a/assets/site.js
+++ b/assets/site.js
@@ -1,3 +1,18 @@
+Events = {
+  permalink: function(id) {
+    ga('send', 'event', 'permalink', 'created', id)
+  },
+
+  permalink_error: function(value) {
+    ga('send', 'event', 'permalink', 'error', "" + value);
+  },
+
+  download: function() {
+    ga('send', 'event', 'download', 'clicked');
+  }
+
+}
+
 function getParam(name) {
     name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
     var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),

--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
       setPermalink(data.id);
 
       // send analytics event
-      Events.permalink(data.id);
+      Events.permalink();
 
       // mark what we last saved
       lastSaved = input;

--- a/index.html
+++ b/index.html
@@ -318,9 +318,15 @@
       return false;
     })
 
-    // if there's no CSV to download, don't download anything
+    // if there's no CSV to download, don't download anything.
+    // also, log an analytics event.
     $(".csv a.download").click(function() {
-      return !!$(".csv textarea").val();
+      var data = $(".csv textarea").val();
+      if (data) {
+        Events.download(data.length);
+        return true;
+      } else
+        return false;
     });
 
     // Both elements are present on page-load, so use normal click handler.

--- a/index.html
+++ b/index.html
@@ -207,6 +207,9 @@
       // take new Gist id, make permalink
       setPermalink(data.id);
 
+      // send analytics event
+      Events.permalink(data.id);
+
       // mark what we last saved
       lastSaved = input;
 
@@ -217,6 +220,10 @@
 
     }).fail(function(xhr, status, errorThrown) {
       console.log(xhr);
+
+      // send analytics event
+      Events.permalink_error(status);
+
       // TODO: gracefully handle rate limit errors
       // if (status == 403)
 


### PR DESCRIPTION
This adds event tracking in Google Analytics for 3 things:
- When a permalink is successfully created. The ID of the permalink is **not** sent to Google Analytics. This will give me an idea of how many people are using this feature.
- When a permalink is unsuccessfully created. The HTTP status code of the error is sent to Google Analytics. This will give me an idea of how often GitHub's anonymous gist creation rate limits are reached.
- When the CSV download link is clicked, and the content is non-empty. The length of the content is sent to Google Analytics. This will give me an idea of the size of data people are using the site for, as well as how often people actually end up using the site's core function.

No events are triggered simply by a user entering, pasting, or modifying content in the text area. No information about the content they have entered is sent to Google Analytics, other than the length of the content (the size of the data) if they go ahead and download the resulting CSV.

I'm happy to share the stats I collect with anyone at any time.
