### PR TITLE
Add option to render all rows

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -13,7 +13,7 @@ h1 {
 
 
 /* position textareas and renderings over each other */
-.areas {position: relative; width: 90%; height: 17em;}
+.areas {position: relative; width: 90%; height: 18em;}
 
 .json textarea,
 .json pre,
@@ -60,6 +60,8 @@ h1 {
 .csv table tr {background-color: #fff;}
 .csv table thead tr,
 .csv table tbody tr:nth-child(2n) {background-color: #f8f8f8;}
+
+.render-all {display: none;}
 
 .csv td, .csv th {
   max-width: 250px;

--- a/index.html
+++ b/index.html
@@ -96,6 +96,17 @@ but: only check when on the production domain.
     return true;
   }
 
+  function renderAll(e) {
+    var json = jsonFrom(input);
+    var inArray = arrayFrom(json);
+    var outArray = [];
+    for (var row in inArray) {
+      outArray[outArray.length] = parse_object(inArray[row]);
+    }
+    renderCSV(outArray);
+    $(".render-all").hide();
+  }
+
   // show rendered JSON
   function showJSON(rendered) {
     console.log("ordered to show JSON: " + rendered);
@@ -178,6 +189,7 @@ but: only check when on the production domain.
     // excerpt and render first 10 rows
     renderCSV(outArray.slice(0, excerptRows));
     showCSV(true);
+    $(".render-all").show();
 
     // show raw data if people really want it
     $(".csv textarea").val(csv);
@@ -328,6 +340,8 @@ but: only check when on the production domain.
       return false;
     })
 
+    $(".render-all").click(function(e) {renderAll(e);});
+
     // if there's no CSV to download, don't download anything.
     // also, log an analytics event.
     $(".csv a.download").click(function() {
@@ -476,6 +490,7 @@ but: only check when on the production domain.
     <textarea class="editing" readonly></textarea>
     <div class="table rendered">
       <table></table>
+      <a href="#" class="render-all">Show all <span class="rows count"></span> rows</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Added a *show all* link that enables user to show a table with the full JSON list (#166):

* The link is only shown when the table is rendered;
* The link is hidden after clicking on it, becoming visible only when changing the JSON content again;
* The `.areas` size was resized to 18em to have sufficient space for the new link element

Thanks!