### PR TITLE
Update title and description to emphasize privacy and speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-<title>JSON to CSV</title>
-<meta name="og:title" content="JSON to CSV" />
+<title>JSON to CSV Converter</title>
+<meta name="og:title" content="JSON to CSV Converter" />
 
-<meta name="description" content="A simple, in-browser JSON viewer, and CSV converter." />
-<meta name="og:description" content="A simple, in-browser JSON viewer and CSV converter." />
+<meta name="description" content="A simple, private JSON-to-CSV converter. Your data is never shared with our servers." />
+<meta name="og:description" content="A simple, private JSON-to-CSV converter. Your data is never shared with our servers." />
 
 <meta name="author" content="Eric Mill" />
 <meta name="twitter:creator" content="@konklone" />
@@ -15,16 +15,6 @@
 
 <link rel="shortcut icon" href="/json/favicon.png" />
 <link rel="canonical" href="https://konklone.io/json/" />
-
-<!--
-redirect users to the https version of the website.
-but: only check when on the production domain.
--->
-<script type="text/javascript">
-  var enforce = "konklone.io";
-  if ((enforce == window.location.host) && (window.location.protocol != "https:"))
-    window.location.protocol = "https";
-</script>
 
 <!-- JSON5 parser -->
 <script src='assets/json5-2.1.0.min.js'></script>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
 <title>JSON to CSV Converter</title>
 <meta name="og:title" content="JSON to CSV Converter" />
 
-<meta name="description" content="A simple, private JSON-to-CSV converter. Your data is never shared with our servers." />
-<meta name="og:description" content="A simple, private JSON-to-CSV converter. Your data is never shared with our servers." />
+<meta name="description" content="A fast, private JSON-to-CSV converter. Your data is never shared with our servers." />
+<meta name="og:description" content="A fast, private JSON-to-CSV converter. Your data is never shared with our servers." />
 
 <meta name="author" content="Eric Mill" />
 <meta name="twitter:creator" content="@konklone" />


### PR DESCRIPTION
The site is popular and gets ~400K sessions per year, and is #2 on Google for `json to csv` and `json to csv converter`. 

But #2 isn't good enough! After taking a look at my competition and my SEO, I think it's worth adding `Converter` to the title, and emphasizing the privacy of the tool. Since conversion is done all inside the browser, data is never sent to our servers. That is a major differentiator from my competition, and privacy is something people care more about every year.

I also removed the old JS-based redirect to HTTPS. The site is now using GitHub Pages' support for HTTPS for custom domains. Not contained in this PR, but I also dropped the free CloudFlare proxy in front of it, for simplicity and to rely on GitHub's fully authenticated HTTPS connection.