### PR TITLE
An option to select a separator (comma, tab or semicolon) is added.

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -43,6 +43,7 @@ h1 {
 
 .json .error a.report {font-weight: bold;}
 .json .warning {margin-top: 5px; color: #888;}
+.json .separator {margin-top: 5px; }
 .json .error {
   display: none;
   margin-top: 5px;

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 <script>
   var excerptRows = 7;
   var input;
+  var separator;
   var url;
 
   function doJSON() {
@@ -42,7 +43,8 @@
 
     // get input JSON, try to parse it
     var newInput = $(".json textarea").val();
-    if (newInput == input) return;
+    var newSeparator = getSeparator();
+    if (newInput == input && newSeparator == separator) return;
 
     input = newInput;
     if (!input) {
@@ -51,6 +53,7 @@
       return;
     }
 
+    separator = newSeparator;
     var json = jsonFrom(input);
 
     // if succeeded, prettify and highlight it
@@ -115,6 +118,23 @@
     }
   }
 
+  function getSeparator() {
+    var separator = $(".json .separator select").val();
+    
+    switch (separator) {
+      case "tab":
+        return "\t";
+        break;
+      case "semicolon":
+        return ';';
+        break;
+      case "comma":
+      default:
+        return ',';
+        break;
+    }
+  }
+
   // takes an array of flat JSON objects, converts them to arrays
   // renders them into a small table as an example
   function renderCSV(objects) {
@@ -166,7 +186,7 @@
 
     $("span.rows.count").text("" + outArray.length);
 
-    var csv = $.csv.fromObjects(outArray);
+    var csv = $.csv.fromObjects(outArray, {separator: getSeparator()});
     // excerpt and render first few rows
     renderCSV(outArray.slice(0, excerptRows));
     showCSV(true);
@@ -213,6 +233,7 @@
 
     $(".json textarea").blur(function() {showJSON(true);});
     $(".json pre").click(function() {showJSON(false)});
+    $(".json .separator select").change(function() {doJSON();});
     $(".csv textarea").blur(function() {showCSV(true);})
     $(".csv .raw").click(function() {
       showCSV(false);
@@ -326,6 +347,15 @@
     <textarea class="editing"></textarea>
     <pre class="rendered"><code></code></pre>
     <div class="drop">DROP JSON HERE</div>
+  </div>
+
+  <div class="separator">
+    Separator
+    <select name="separator">
+      <option value="comma" selected>Comma</option>
+      <option value="tab">Tab</option>
+      <option value="semicolon">Semicolon</option>
+    </select>
   </div>
 
   <div class="warning">


### PR DESCRIPTION
This change adds an option to select a separator for the CSV:
- Comma (default)
- Tab
- Semicolon.

![image](https://user-images.githubusercontent.com/187887/47707285-24496500-dc34-11e8-9a01-2776fbde9cfd.png)

Steps to review:
1. Paste JSON into the textarea.
2. Click on _Show the raw data_ and see that comma is used as a separator.
3. Change the separator to _Tab_, click on _Show the raw data_ and see that tab is used as a separator.
3. Change the separator to _Semicolon_, click on _Download the entire CSV_ and see that in the downloaded file semicolon is used as a separator.